### PR TITLE
feat: add support for priority method

### DIFF
--- a/example/explorer_example.dart
+++ b/example/explorer_example.dart
@@ -7,7 +7,9 @@ ExplorerClient explorer =
 void main() async {
   try {
     Status status = await explorer.status();
+    PrioritiesEstimate priority = await explorer.valueTransferPriority();
     print("Status: ${status.databaseMessage}");
+    print("Priority ${priority.vttHigh.priority}");
   } on ExplorerException catch (e) {
     print(e.message);
   }

--- a/example/explorer_example.dart
+++ b/example/explorer_example.dart
@@ -7,7 +7,7 @@ ExplorerClient explorer =
 void main() async {
   try {
     Status status = await explorer.status();
-    print(status.databaseMessage);
+    print("Status: ${status.databaseMessage}");
   } on ExplorerException catch (e) {
     print(e.message);
   }

--- a/lib/explorer.dart
+++ b/lib/explorer.dart
@@ -1,3 +1,5 @@
+import 'package:witnet/src/network/explorer/explorer_api.dart';
+
 export 'src/network/explorer/explorer_client.dart'
     show ExplorerClient, ExplorerMode;
 
@@ -18,4 +20,5 @@ export 'src/network/explorer/explorer_api.dart'
         AddressValueTransfers,
         MintInfo,
         TallyTxn,
-        ValueTransferInfo;
+        ValueTransferInfo,
+        PrioritiesEstimate;

--- a/lib/src/network/explorer/explorer_api.dart
+++ b/lib/src/network/explorer/explorer_api.dart
@@ -1535,3 +1535,82 @@ class HashInfo {
         "block_hash": blockHash,
       };
 }
+
+class PrioritiesEstimate {
+  PrioritiesEstimate({
+    // required this.drtStinky,
+    // required this.drtLow,
+    // required this.drtMedium,
+    // required this.drtHigh,
+    // required this.drtOpulent,
+    required this.vttStinky,
+    required this.vttLow,
+    required this.vttMedium,
+    required this.vttHigh,
+    required this.vttOpulent,
+  });
+
+  // final PriorityEstimate drtStinky;
+  // final PriorityEstimate drtLow;
+  // final PriorityEstimate drtMedium;
+  // final PriorityEstimate drtHigh;
+  // final PriorityEstimate drtOpulent;
+  final PriorityEstimate vttStinky;
+  final PriorityEstimate vttLow;
+  final PriorityEstimate vttMedium;
+  final PriorityEstimate vttHigh;
+  final PriorityEstimate vttOpulent;
+
+  factory PrioritiesEstimate.fromRawJson(String str) =>
+      PrioritiesEstimate.fromJson(json.decode(str));
+
+  String toRawJson() => json.encode(jsonMap());
+
+  factory PrioritiesEstimate.fromJson(Map<String, dynamic> json) {
+    return PrioritiesEstimate(
+        // drtStinky: PriorityEstimate.fromJson(json["drt_stinky"]),
+        // drtLow: PriorityEstimate.fromJson(json["drt_low"]),
+        // drtMedium: PriorityEstimate.fromJson(json["drt_medium"]),
+        // drtHigh: PriorityEstimate.fromJson(json["drt_high"]),
+        // drtOpulent: PriorityEstimate.fromJson(json["drt_opulent"]),
+        vttStinky: PriorityEstimate.fromJson(json["vtt_stinky"]),
+        vttLow: PriorityEstimate.fromJson(json["vtt_low"]),
+        vttMedium: PriorityEstimate.fromJson(json["vtt_medium"]),
+        vttHigh: PriorityEstimate.fromJson(json["vtt_high"]),
+        vttOpulent: PriorityEstimate.fromJson(json["vtt_opulent"]));
+  }
+
+  Map<String, PriorityEstimate> jsonMap() => {
+        // "drt_stinky": drtStinky,
+        // "drt_low": drtLow,
+        // "drt_medium": drtMedium,
+        // "drt_high": drtHigh,
+        // "drt_opulent": drtOpulent,
+        "vtt_stinky": vttStinky,
+        "vtt_low": vttLow,
+        "vtt_medium": vttMedium,
+        "vtt_high": vttHigh,
+        "vtt_opulent": vttOpulent,
+      };
+}
+
+class PriorityEstimate {
+  PriorityEstimate({
+    required this.priority,
+    required this.timeToBlock,
+  });
+
+  final double priority;
+  final int timeToBlock;
+
+  factory PriorityEstimate.fromJson(Map<String, dynamic> json) =>
+      PriorityEstimate(
+        priority: json["priority"],
+        timeToBlock: json["time_to_block"],
+      );
+
+  Map<String, dynamic> jsonMap() => {
+        "priority": priority,
+        "time_to_block": timeToBlock,
+      };
+}

--- a/lib/src/network/explorer/explorer_client.dart
+++ b/lib/src/network/explorer/explorer_client.dart
@@ -19,6 +19,7 @@ import 'explorer_api.dart'
         Home,
         MintInfo,
         Network,
+        PrioritiesEstimate,
         Status,
         Tapi;
 
@@ -281,6 +282,15 @@ class ExplorerClient {
       return response;
     } catch (e) {
       rethrow;
+    }
+  }
+
+  Future<PrioritiesEstimate> valueTransferPriority() async {
+    try {
+      return PrioritiesEstimate.fromJson(await _processGet(api('priority', { "type": "vtt" })));
+    } on ExplorerException catch (e) {
+      throw ExplorerException(
+          code: e.code, message: '{"priority": "${e.message}"}');
     }
   }
 }


### PR DESCRIPTION
Add support for priority method using the same types used in witnet/witnet-rust#2261.

This PR could be merged once the inventory method is implemented in the Witnet Block Explorer.