### PR TITLE
feat(node_client): better return types and additional methods

### DIFF
--- a/lib/src/network/node/node_api.dart
+++ b/lib/src/network/node/node_api.dart
@@ -187,3 +187,14 @@ class SyncStatus {
         "node_state": nodeState,
       };
 }
+
+class Peer {
+  String address;
+  String ipv4;
+  int port;
+  String type;
+  Peer({required this.address, required this.type}) : this.ipv4 = address.split(":")[0], this.port = int.parse(address.split(":")[1]);
+  factory Peer.fromJson(Map<String, dynamic> data) {
+    return Peer(address: data["address"], type: data["type"]);
+  }
+}

--- a/lib/src/schema/consensus_constants.dart
+++ b/lib/src/schema/consensus_constants.dart
@@ -44,7 +44,6 @@ class ConsensusConstants extends GeneratedMessage {
   @override
   ConsensusConstants clone() => ConsensusConstants()..mergeFromMessage(this);
 
-
   @override
   ConsensusConstants createEmptyInstance() => create();
 
@@ -158,13 +157,66 @@ class ConsensusConstants extends GeneratedMessage {
 
   @override
   factory ConsensusConstants.fromBuffer(List<int> i,
-          [ExtensionRegistry r = ExtensionRegistry.EMPTY]) =>
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY]) =>
       create()..mergeFromBuffer(i, r);
 
   @override
-  factory ConsensusConstants.fromJson(String i,
-          [ExtensionRegistry r = ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ConsensusConstants.fromJson(Map<String, dynamic> data) =>
+      ConsensusConstants(
+        activityPeriod: data['activity_period'],
+        bootstrapHash:  Hash(SHA256: hexToBytes(data['bootstrap_hash'])),
+        bootstrappingCommittee:  List<String>.from(data['bootstrapping_committee']),
+        checkpointZeroTimestamp:  Int64(data['checkpoint_zero_timestamp']),
+        checkpointsPeriod:  data['checkpoints_period'],
+        collateralAge:  data['collateral_age'],
+        collateralMinimum:  Int64(data['collateral_minimum']),
+        epochsWithMinimumDifficulty:  data['epochs_with_minimum_difficulty'],
+        extraRounds:  data['extra_rounds'],
+        genesisHash:  Hash(SHA256: hexToBytes(data['genesis_hash'])),
+        halvingPeriod:  data['halving_period'],
+        initialBlockReward:  Int64(data['initial_block_reward']),
+        maxDrWeight:  data['max_dr_weight'],
+        maxVtWeight:  data['max_vt_weight'],
+        minimumDifficulty:  data['minimum_difficulty'],
+        miningBackupFactor:  data['mining_backup_factor'],
+        miningReplicationFactor:  data['mining_replication_factor'],
+        reputationExpireAlphaDiff:  data['reputation_expire_alpha_diff'],
+        reputationIssuance:  data['reputation_issuance'],
+        reputationIssuanceStop:  data['reputation_issuance_stop'],
+        reputationPenalizationFactor:  data['reputation_penalization_factor'],
+        superblockCommitteeDecreasingPeriod:  data['superblock_committee_decreasing_period'],
+        superblockCommitteeDecreasingStep:  data['superblock_committee_decreasing_step'],
+        superblockPeriod:  data['superblock_period'],
+        superblockSigningCommitteeSize:  data['superblock_signing_committee_size'],
+      );
+
+  Map<String, dynamic> jsonMap() => {
+    'activity_period': activityPeriod,
+    'bootstrap_hash': bootstrapHash.hex,
+    'bootstrapping_committee': bootstrappingCommittee,
+    'checkpoint_zero_timestamp': checkpointZeroTimestamp.toInt(),
+    'checkpoints_period': checkpointsPeriod,
+    'collateral_age': collateralAge,
+    'collateral_minimum': collateralMinimum.toInt(),
+    'epochs_with_minimum_difficulty': epochsWithMinimumDifficulty,
+    'extra_rounds': extraRounds,
+    'genesis_hash': genesisHash.hex,
+    'halving_period': halvingPeriod,
+    'initial_block_reward': initialBlockReward.toInt(),
+    'max_dr_weight': maxDrWeight,
+    'max_vt_weight': maxVtWeight,
+    'minimum_difficulty': minimumDifficulty,
+    'mining_backup_factor': miningBackupFactor,
+    'mining_replication_factor': miningReplicationFactor,
+    'reputation_expire_alpha_diff': reputationExpireAlphaDiff,
+    'reputation_issuance': reputationIssuance,
+    'reputation_issuance_stop': reputationIssuanceStop,
+    'reputation_penalization_factor': reputationPenalizationFactor,
+    'superblock_committee_decreasing_period': superblockCommitteeDecreasingPeriod,
+    'superblock_committee_decreasing_step': superblockCommitteeDecreasingStep,
+    'superblock_period': superblockPeriod,
+    'superblock_signing_committee_size': superblockSigningCommitteeSize
+  };
 
   @override
   BuilderInfo get info_ => _i;

--- a/lib/src/schema/data_request_transaction.dart
+++ b/lib/src/schema/data_request_transaction.dart
@@ -41,15 +41,15 @@ class DRTransaction extends GeneratedMessage {
 
   @override
   factory DRTransaction.fromBuffer(List<int> i,
-          [ExtensionRegistry r = ExtensionRegistry.EMPTY]) =>
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY]) =>
       create()..mergeFromBuffer(i, r);
 
   @override
   factory DRTransaction.fromJson(Map<String, dynamic> json) => DRTransaction(
-        body: DRTransactionBody.fromJson(json["body"]),
-        signatures: List<KeyedSignature>.from(
-            json["signatures"].map((x) => KeyedSignature.fromJson(x))),
-      );
+    body: DRTransactionBody.fromJson(json["body"]),
+    signatures: List<KeyedSignature>.from(
+        json["signatures"].map((x) => KeyedSignature.fromJson(x))),
+  );
 
   String rawJson({bool asHex = false}) => json.encode(jsonMap(asHex: asHex));
 
@@ -58,7 +58,7 @@ class DRTransaction extends GeneratedMessage {
       "DataRequest": {
         "body": body.jsonMap(asHex: asHex),
         "signatures":
-            List<dynamic>.from(signatures.map((x) => x.jsonMap(asHex: asHex))),
+        List<dynamic>.from(signatures.map((x) => x.jsonMap(asHex: asHex))),
       }
     };
   }

--- a/lib/src/schema/output_pointer.dart
+++ b/lib/src/schema/output_pointer.dart
@@ -36,13 +36,13 @@ class OutputPointer extends GeneratedMessage {
   }
 
   factory OutputPointer.fromString(String str) => OutputPointer(
-        transactionId: Hash.fromString(str.split(':')[0]),
-        outputIndex: int.parse(str.split(':')[1]),
-      );
+    transactionId: Hash.fromString(str.split(':')[0]),
+    outputIndex: int.parse(str.split(':')[1]),
+  );
 
   @override
   factory OutputPointer.fromBuffer(List<int> i,
-          [ExtensionRegistry r = ExtensionRegistry.EMPTY]) =>
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY]) =>
       create()..mergeFromBuffer(i, r);
 
   String rawJson({bool asHex = false}) => json.encode(jsonMap(asHex: asHex));

--- a/lib/src/schema/public_key.dart
+++ b/lib/src/schema/public_key.dart
@@ -53,8 +53,8 @@ class PublicKey extends GeneratedMessage {
     if (publicKey.isNotEmpty)
       return {
         "bytes": (asHex)
-            ? bytesToHex(Uint8List.fromList(publicKey.sublist(2)))
-            : publicKey.sublist(2),
+            ? bytesToHex(Uint8List.fromList(publicKey.sublist(1)))
+            : publicKey.sublist(1),
         "compressed": publicKey[0],
       };
     return {};

--- a/lib/src/schema/public_key.dart
+++ b/lib/src/schema/public_key.dart
@@ -38,7 +38,7 @@ class PublicKey extends GeneratedMessage {
 
   @override
   factory PublicKey.fromBuffer(List<int> i,
-          [ExtensionRegistry r = ExtensionRegistry.EMPTY]) =>
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY]) =>
       create()..mergeFromBuffer(i, r);
 
   @override
@@ -49,11 +49,12 @@ class PublicKey extends GeneratedMessage {
   }
 
   Map<String, dynamic> jsonMap({bool asHex = false}) {
+
     if (publicKey.isNotEmpty)
       return {
         "bytes": (asHex)
-            ? bytesToHex(Uint8List.fromList(publicKey.sublist(1)))
-            : publicKey.sublist(1),
+            ? bytesToHex(Uint8List.fromList(publicKey.sublist(2)))
+            : publicKey.sublist(2),
         "compressed": publicKey[0],
       };
     return {};

--- a/lib/src/schema/rad_retrieve.dart
+++ b/lib/src/schema/rad_retrieve.dart
@@ -59,7 +59,7 @@ class RADRetrieve extends GeneratedMessage {
 
   @override
   factory RADRetrieve.fromBuffer(List<int> i,
-          [ExtensionRegistry r = ExtensionRegistry.EMPTY]) =>
+      [ExtensionRegistry r = ExtensionRegistry.EMPTY]) =>
       create()..mergeFromBuffer(i, r);
 
   factory RADRetrieve.fromRawJson(String str) =>
@@ -67,18 +67,18 @@ class RADRetrieve extends GeneratedMessage {
 
   @override
   factory RADRetrieve.fromJson(Map<String, dynamic> json) => RADRetrieve(
-        kind: RADType.fromString(json["kind"]),
-        script: List<int>.from(json["script"].map((x) => x)),
-        url: (json["url"] != "") ? json["url"] : null,
-        body: (json["body"] != null)
-            ? List<int>.from(json["body"].map((x) => x))
-            : null,
-        headers: (json["headers"] != null)
-            ? List<StringPair>.from((json["headers"] as Map<String, String>)
-                .entries
-                .map((e) => StringPair(left: e.key, right: e.value)))
-            : null,
-      );
+    kind: RADType.fromString(json["kind"]),
+    script: List<int>.from(json["script"].map((x) => x)),
+    url: (json["url"] != "") ? json["url"] : null,
+    body: (json["body"] != null)
+        ? List<int>.from(json["body"].map((x) => x))
+        : null,
+    headers: (json["headers"] != null)
+        ? List<StringPair>.from((json["headers"] as Map<String, String>)
+        .entries
+        .map((e) => StringPair(left: e.key, right: e.value)))
+        : null,
+  );
 
   String toRawJson({bool asHex = false}) => json.encode(jsonMap(asHex: asHex));
 

--- a/lib/src/schema/secp256k1_signature.dart
+++ b/lib/src/schema/secp256k1_signature.dart
@@ -50,8 +50,8 @@ class Secp256k1Signature extends GeneratedMessage {
   String rawJson({bool asHex = false}) => json.encode(jsonMap(asHex: asHex));
 
   Map<String, dynamic> jsonMap({bool asHex = false}) => {
-        "der": (asHex) ? bytesToHex(Uint8List.fromList(der)) : der.toList(),
-      };
+    "der": (asHex) ? bytesToHex(Uint8List.fromList(der)) : der.toList(),
+  };
 
   @override
   BuilderInfo get info_ => _i;


### PR DESCRIPTION
- add `sendVTTransaction` and `sendDRTransaction` methods, previously it was required to use the `inventory` method
- add `ConsensusConstants` json to the protobuf schema and as return type in the node client
- refactor return types for peer methods to return a list of peers instead of a raw json map