### PR TITLE
feat(explorer_client): add mempool method

### DIFF
--- a/lib/src/network/explorer/explorer_client.dart
+++ b/lib/src/network/explorer/explorer_client.dart
@@ -198,12 +198,14 @@ class ExplorerClient {
     }
   }
 
-  Future<dynamic> pending() async {
+  Future<dynamic> mempool({String key = 'live'}) async {
     try {
-      return await _processGet(api('pending'));
+      if (['live', 'history'].contains(key)){
+        return await _processGet(api('mempool', {'key': '$key'}));
+      }
     } on ExplorerException catch (e) {
       throw ExplorerException(
-          code: e.code, message: '{"pending": "${e.message}"}');
+          code: e.code, message: '{"mempool": "${e.message}"}');
     }
   }
 


### PR DESCRIPTION
the old `pending` method only returned the "history" view of the past 24 hours. the new `mempool` method has a key that can be "live" or "history"

https://witnet.network/api/mempool?key=live
https://witnet.network/api/mempool?key=history