### PR TITLE
feat(ExplorerClient): add `address_info` endpoint

### DIFF
--- a/lib/src/network/explorer/explorer_api.dart
+++ b/lib/src/network/explorer/explorer_api.dart
@@ -907,6 +907,58 @@ class AddressValueTransfers {
       };
 }
 
+class AddressInfo {
+  final String address;
+  final String label;
+  final int active;
+  final int block;
+  final int mint;
+  final int value_transfer;
+  final int data_request;
+  final int commit;
+  final int reveal;
+  final int tally;
+
+  AddressInfo({
+    required this.address,
+    required this.label,
+    required this.active,
+    required this.block,
+    required this.mint,
+    required this.value_transfer,
+    required this.data_request,
+    required this.commit,
+    required this.reveal,
+    required this.tally,
+  });
+
+  factory AddressInfo.fromJson(Map<String, dynamic> json) => AddressInfo(
+        address: json["address"],
+        label: json["label"],
+        active: json["active"],
+        block: json["block"],
+        mint: json["mint"],
+        value_transfer: json["value_transfer"],
+        data_request: json["data_request"],
+        commit: json["commit"],
+        reveal: json["reveal"],
+        tally: json["tally"],
+      );
+
+  Map<String, dynamic> jsonMap() => {
+        "address": address,
+        "label": label,
+        "active": active,
+        "block": block,
+        "mint": mint,
+        "value_transfer": value_transfer,
+        "data_request": data_request,
+        "commit": commit,
+        "reveal": reveal,
+        "tally": tally,
+      };
+}
+
 class MintInfo {
   MintInfo({
     required this.blockHash,

--- a/lib/src/network/explorer/explorer_client.dart
+++ b/lib/src/network/explorer/explorer_client.dart
@@ -12,6 +12,7 @@ import 'explorer_api.dart'
         AddressBlocks,
         AddressDataRequestsSolved,
         AddressDetails,
+        AddressInfo,
         AddressValueTransfers,
         Blockchain,
         ExplorerException,
@@ -250,6 +251,17 @@ class ExplorerClient {
     } on ExplorerException catch (e) {
       throw ExplorerException(
           code: e.code, message: '{"address": "${e.message}"}');
+    }
+  }
+
+  Future<AddressInfo> addressInfo({required String address}) async {
+    try {
+      var data = await _processGet(api('address_info', {'address': address}));
+
+      return AddressInfo.fromJson( data[address] );
+    } on ExplorerException catch (e) {
+      throw ExplorerException(
+          code: e.code, message: '{"address_info": "${e.message}"}');
     }
   }
 


### PR DESCRIPTION
```dart
// address_info_test.dart
import 'package:witnet/explorer.dart';
import 'package:witnet/src/network/explorer/explorer_api.dart';

void main() async {
  ExplorerClient client =
      ExplorerClient(url: "witnet.network", mode: ExplorerMode.production);
  AddressInfo addressInfo = await client.addressInfo(
      address: "wit1drcpu0xc2akfcqn8r69vw70pj8fzjhjypdcfsq");
  print(addressInfo.jsonMap());
}
```
```bash
$ dart address_info_test.dart
> {address: wit1drcpu0xc2akfcqn8r69vw70pj8fzjhjypdcfsq, label: , active: 1890302, block: 65, mint: 65, value_transfer: 90, data_request: 4272, commit: 1802, reveal: 1802, tally: 2987}
```
Closes #18 